### PR TITLE
Github first PING is missing the repository key

### DIFF
--- a/src/lib/routes.coffee
+++ b/src/lib/routes.coffee
@@ -11,6 +11,8 @@ exports.notify = (req, res) ->
   options = req.clabotOptions
   payload = JSON.parse req.body.payload
 
+  return res.send(200) unless payload.repository?
+
   repo   = payload.repository.name
   user   = payload.repository.owner.login
 


### PR DESCRIPTION
When you set up the webhook, github sends a PING request that misses the "repository" key. With this PR, when "repository" is missing, a 200 is returned
