### PR TITLE
Add ability to pass in Express app vs. relying on clabot to create one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ app = require('clabot').createApp(options);
 app.listen(process.env.PORT || 1337);
 ```
 
+If your app requires middleware to be added before clabot's middleware, you can pass in an Express app for clabot to use instead of creating a new one.
+
+```js
+options.app = express();
+// add some middleware here
+app = require('clabot').createApp(options);
+app.listen(process.env.PORT || 1337);
+```
+
 In order to receive events from GitHub you have to subscribe.
 clabot will never push code to the repositories, but push access is required to be able to receive events from the GitHub API.
 

--- a/src/clabot.coffee
+++ b/src/clabot.coffee
@@ -13,6 +13,9 @@ exports.createApp = (options) ->
     skipContributors: yes
     skipCollaborators: no
 
+  # Create new Express app
+  app = if options.app then options.app else express()
+
   # Just pick the options we need
   options = _.pick options, [
     'getContractors'
@@ -24,9 +27,6 @@ exports.createApp = (options) ->
     'skipCollaborators'
     'skipContributors'
   ]
-
-  # Create new Express app
-  app = express()
 
   # Apply middlewares
   app.use middlewares.allowCrossDomain


### PR DESCRIPTION
This fixes compatibility issues where some modules, such as passport,
require middleware to be added first. Since clabot creates the express
app and adds some middleware immediately, it was previously incompatible
with passport.
