### PR TITLE
req.body.payload is undefined which fails.

### DIFF
--- a/src/lib/routes.coffee
+++ b/src/lib/routes.coffee
@@ -9,7 +9,7 @@ answerPullRequest = require './answerPullRequest'
 
 exports.notify = (req, res) ->
   options = req.clabotOptions
-  payload = JSON.parse req.body.payload
+  payload = JSON.parse req.rawBody
 
   return res.send(200) unless payload.repository?
 


### PR DESCRIPTION
Parsing the rawBody instead seems to work fine.
Fixes Issue #8
